### PR TITLE
Homework2.2.1 ViewDidLoad used only

### DIFF
--- a/SwiftBook/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SwiftBook/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -72,6 +72,11 @@
     },
     {
       "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
       "scale" : "2x",
       "size" : "76x76"
     },

--- a/SwiftBook/Base.lproj/LaunchScreen.storyboard
+++ b/SwiftBook/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,10 +13,22 @@
             <objects>
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hAr-cs-p3O">
+                                <rect key="frame" x="140.5" y="428.5" width="133" height="39"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="32"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="hAr-cs-p3O" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="ijY-6X-54W"/>
+                            <constraint firstItem="hAr-cs-p3O" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="qdS-7J-KwL"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -22,4 +36,9 @@
             <point key="canvasLocation" x="53" y="375"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/SwiftBook/Base.lproj/Main.storyboard
+++ b/SwiftBook/Base.lproj/Main.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,63 +14,75 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="SwiftBook" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="Uus-Ye-iN0">
-                                <rect key="frame" x="128" y="74" width="158" height="490"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" spacing="80" translatesAutoresizingMaskIntoConstraints="NO" id="IJb-Dm-Xah">
+                                <rect key="frame" x="113.00000000000001" y="79" width="202.33333333333337" height="768"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P7P-zn-lAU" userLabel="RedCircleView">
-                                        <rect key="frame" x="0.0" y="0.0" width="158" height="158"/>
-                                        <color key="backgroundColor" systemColor="systemRedColor"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Uus-Ye-iN0">
+                                        <rect key="frame" x="0.0" y="0.0" width="202.33333333333334" height="647"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P7P-zn-lAU" userLabel="RedCircleView">
+                                                <rect key="frame" x="0.0" y="0.0" width="202.33333333333334" height="202.33333333333334"/>
+                                                <color key="backgroundColor" systemColor="systemRedColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="P7P-zn-lAU" secondAttribute="height" multiplier="1:1" id="4P5-vC-WwC"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8vP-ld-Ecf" userLabel="YellowCircleView">
+                                                <rect key="frame" x="0.0" y="222.33333333333331" width="202.33333333333334" height="202.33333333333331"/>
+                                                <color key="backgroundColor" systemColor="systemYellowColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="8vP-ld-Ecf" secondAttribute="height" multiplier="1:1" id="Va3-1m-vUm"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ovq-tt-WTY" userLabel="GreenCircleView">
+                                                <rect key="frame" x="0.0" y="444.66666666666657" width="202.33333333333334" height="202.33333333333331"/>
+                                                <color key="backgroundColor" systemColor="systemGreenColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="Ovq-tt-WTY" secondAttribute="height" multiplier="1:1" id="rfZ-XJ-3io"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                        <variation key="heightClass=compact-widthClass=compact" axis="horizontal"/>
+                                        <variation key="heightClass=compact-widthClass=regular" axis="horizontal"/>
+                                    </stackView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jiv-AV-dvV">
+                                        <rect key="frame" x="0.0" y="727" width="202.33333333333334" height="41"/>
+                                        <color key="backgroundColor" name="AccentColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" secondItem="P7P-zn-lAU" secondAttribute="height" multiplier="1:1" id="4P5-vC-WwC"/>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="41" id="sZh-jo-dhw"/>
                                         </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8vP-ld-Ecf" userLabel="YellowCircleView">
-                                        <rect key="frame" x="0.0" y="166" width="158" height="158"/>
-                                        <color key="backgroundColor" systemColor="systemYellowColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="8vP-ld-Ecf" secondAttribute="height" multiplier="1:1" id="Va3-1m-vUm"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ovq-tt-WTY" userLabel="GreenCircleView">
-                                        <rect key="frame" x="0.0" y="332" width="158" height="158"/>
-                                        <color key="backgroundColor" systemColor="systemGreenColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="Ovq-tt-WTY" secondAttribute="height" multiplier="1:1" id="rfZ-XJ-3io"/>
-                                        </constraints>
-                                    </view>
+                                        <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="START">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="startNextColorLightButtonTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="KEK-rj-lfz"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
+                                <variation key="heightClass=compact-widthClass=compact" axis="horizontal"/>
+                                <variation key="heightClass=compact-widthClass=regular" axis="horizontal"/>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jiv-AV-dvV">
-                                <rect key="frame" x="167" y="791" width="80" height="41"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="48j-nv-T0g"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
-                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                <state key="normal" title="Start"/>
-                                <connections>
-                                    <action selector="startNextColorLightButtonTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="KEK-rj-lfz"/>
-                                </connections>
-                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="Jiv-AV-dvV" secondAttribute="bottom" constant="30" id="9qz-Wl-eYg"/>
-                            <constraint firstItem="Uus-Ye-iN0" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="Pau-gf-Ly4"/>
-                            <constraint firstItem="Uus-Ye-iN0" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="30" id="aeK-85-v9S"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Uus-Ye-iN0" secondAttribute="trailing" constant="128" id="ho6-VY-Qza"/>
-                            <constraint firstItem="Uus-Ye-iN0" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="128" id="uii-DO-v4P"/>
-                            <constraint firstItem="Jiv-AV-dvV" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="zu4-tN-BHw"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IJb-Dm-Xah" secondAttribute="trailing" constant="10" id="72a-fu-kKC"/>
+                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="top" relation="greaterThanOrEqual" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="10" id="AOl-dr-9Qt"/>
+                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="RFX-Rj-9Hu"/>
+                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="10" id="eAi-N4-J7u"/>
+                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="h2g-Tx-iHg"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="IJb-Dm-Xah" secondAttribute="bottom" constant="10" id="irC-rx-Xga"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="greenCircleView" destination="Ovq-tt-WTY" id="Ave-zI-Wve"/>
                         <outlet property="redCircleView" destination="P7P-zn-lAU" id="vdb-yK-m1J"/>
-                        <outlet property="startNextColorLightButton" destination="Jiv-AV-dvV" id="h8e-55-ltG"/>
+                        <outlet property="startButton" destination="Jiv-AV-dvV" id="h8e-55-ltG"/>
                         <outlet property="yellowCircleView" destination="8vP-ld-Ecf" id="ntG-z0-DdS"/>
                     </connections>
                 </viewController>
@@ -80,6 +92,9 @@
         </scene>
     </scenes>
     <resources>
+        <namedColor name="AccentColor">
+            <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/SwiftBook/Base.lproj/Main.storyboard
+++ b/SwiftBook/Base.lproj/Main.storyboard
@@ -3,8 +3,8 @@
     <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,28 +17,28 @@
                         <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" spacing="80" translatesAutoresizingMaskIntoConstraints="NO" id="IJb-Dm-Xah">
-                                <rect key="frame" x="113.00000000000001" y="79" width="202.33333333333337" height="768"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="IJb-Dm-Xah">
+                                <rect key="frame" x="133.33333333333331" y="64" width="161.33333333333331" height="808"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Uus-Ye-iN0">
-                                        <rect key="frame" x="0.0" y="0.0" width="202.33333333333334" height="647"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Uus-Ye-iN0">
+                                        <rect key="frame" x="0.0" y="0.0" width="161.33333333333334" height="544.66666666666663"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P7P-zn-lAU" userLabel="RedCircleView">
-                                                <rect key="frame" x="0.0" y="0.0" width="202.33333333333334" height="202.33333333333334"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="161.33333333333334" height="161.66666666666666"/>
                                                 <color key="backgroundColor" systemColor="systemRedColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="P7P-zn-lAU" secondAttribute="height" multiplier="1:1" id="4P5-vC-WwC"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8vP-ld-Ecf" userLabel="YellowCircleView">
-                                                <rect key="frame" x="0.0" y="222.33333333333331" width="202.33333333333334" height="202.33333333333331"/>
+                                                <rect key="frame" x="0.0" y="191.66666666666669" width="161.33333333333334" height="161.66666666666669"/>
                                                 <color key="backgroundColor" systemColor="systemYellowColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="8vP-ld-Ecf" secondAttribute="height" multiplier="1:1" id="Va3-1m-vUm"/>
                                                 </constraints>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ovq-tt-WTY" userLabel="GreenCircleView">
-                                                <rect key="frame" x="0.0" y="444.66666666666657" width="202.33333333333334" height="202.33333333333331"/>
+                                                <rect key="frame" x="0.0" y="383.33333333333331" width="161.33333333333334" height="161.33333333333331"/>
                                                 <color key="backgroundColor" systemColor="systemGreenColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="Ovq-tt-WTY" secondAttribute="height" multiplier="1:1" id="rfZ-XJ-3io"/>
@@ -49,12 +49,13 @@
                                         <variation key="heightClass=compact-widthClass=regular" axis="horizontal"/>
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jiv-AV-dvV">
-                                        <rect key="frame" x="0.0" y="727" width="202.33333333333334" height="41"/>
-                                        <color key="backgroundColor" name="AccentColor"/>
+                                        <rect key="frame" x="0.0" y="754" width="161.33333333333334" height="54"/>
+                                        <color key="backgroundColor" systemColor="linkColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="41" id="sZh-jo-dhw"/>
+                                            <constraint firstAttribute="width" secondItem="Jiv-AV-dvV" secondAttribute="height" multiplier="3:1" id="O7K-QX-dDK"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                        <color key="tintColor" systemColor="linkColor"/>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                         <state key="normal" title="START">
                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -64,6 +65,9 @@
                                         </connections>
                                     </button>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="IJb-Dm-Xah" secondAttribute="height" multiplier="1:5" id="xWP-VZ-mdK"/>
+                                </constraints>
                                 <variation key="heightClass=compact-widthClass=compact" axis="horizontal"/>
                                 <variation key="heightClass=compact-widthClass=regular" axis="horizontal"/>
                             </stackView>
@@ -71,12 +75,9 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IJb-Dm-Xah" secondAttribute="trailing" constant="10" id="72a-fu-kKC"/>
-                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="top" relation="greaterThanOrEqual" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="10" id="AOl-dr-9Qt"/>
-                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="RFX-Rj-9Hu"/>
-                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="10" id="eAi-N4-J7u"/>
-                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="h2g-Tx-iHg"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="IJb-Dm-Xah" secondAttribute="bottom" constant="10" id="irC-rx-Xga"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="IJb-Dm-Xah" secondAttribute="bottom" constant="20" id="1y0-lK-W0T"/>
+                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="h0h-ih-5eZ"/>
+                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="w7c-iB-KpM"/>
                         </constraints>
                     </view>
                     <connections>
@@ -92,9 +93,9 @@
         </scene>
     </scenes>
     <resources>
-        <namedColor name="AccentColor">
-            <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
+        <systemColor name="linkColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/SwiftBook/Base.lproj/Main.storyboard
+++ b/SwiftBook/Base.lproj/Main.storyboard
@@ -84,7 +84,7 @@
                         <outlet property="greenCircleView" destination="Ovq-tt-WTY" id="Ave-zI-Wve"/>
                         <outlet property="mainStackAspectConstraint" destination="xWP-VZ-mdK" id="4Q1-2D-kpe"/>
                         <outlet property="mainStackBottomConstraint" destination="1y0-lK-W0T" id="ONy-55-vmz"/>
-                        <outlet property="mainStacktopConstraint" destination="h0h-ih-5eZ" id="p8P-et-Qen"/>
+                        <outlet property="mainStackTopConstraint" destination="h0h-ih-5eZ" id="p8P-et-Qen"/>
                         <outlet property="redCircleView" destination="P7P-zn-lAU" id="vdb-yK-m1J"/>
                         <outlet property="startButton" destination="Jiv-AV-dvV" id="h8e-55-ltG"/>
                         <outlet property="yellowCircleView" destination="8vP-ld-Ecf" id="ntG-z0-DdS"/>

--- a/SwiftBook/Base.lproj/Main.storyboard
+++ b/SwiftBook/Base.lproj/Main.storyboard
@@ -75,17 +75,18 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstAttribute="bottom" secondItem="IJb-Dm-Xah" secondAttribute="bottom" constant="54" id="1y0-lK-W0T"/>
-                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" constant="64" id="h0h-ih-5eZ"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="IJb-Dm-Xah" secondAttribute="bottom" constant="20" id="1y0-lK-W0T"/>
+                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="h0h-ih-5eZ"/>
                             <constraint firstItem="IJb-Dm-Xah" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="w7c-iB-KpM"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="bottomConstraint" destination="1y0-lK-W0T" id="ONy-55-vmz"/>
                         <outlet property="greenCircleView" destination="Ovq-tt-WTY" id="Ave-zI-Wve"/>
+                        <outlet property="mainStackAspectConstraint" destination="xWP-VZ-mdK" id="4Q1-2D-kpe"/>
+                        <outlet property="mainStackBottomConstraint" destination="1y0-lK-W0T" id="ONy-55-vmz"/>
+                        <outlet property="mainStacktopConstraint" destination="h0h-ih-5eZ" id="p8P-et-Qen"/>
                         <outlet property="redCircleView" destination="P7P-zn-lAU" id="vdb-yK-m1J"/>
                         <outlet property="startButton" destination="Jiv-AV-dvV" id="h8e-55-ltG"/>
-                        <outlet property="topConstraint" destination="h0h-ih-5eZ" id="p8P-et-Qen"/>
                         <outlet property="yellowCircleView" destination="8vP-ld-Ecf" id="ntG-z0-DdS"/>
                     </connections>
                 </viewController>

--- a/SwiftBook/Base.lproj/Main.storyboard
+++ b/SwiftBook/Base.lproj/Main.storyboard
@@ -75,15 +75,17 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="IJb-Dm-Xah" secondAttribute="bottom" constant="20" id="1y0-lK-W0T"/>
-                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="h0h-ih-5eZ"/>
+                            <constraint firstAttribute="bottom" secondItem="IJb-Dm-Xah" secondAttribute="bottom" constant="54" id="1y0-lK-W0T"/>
+                            <constraint firstItem="IJb-Dm-Xah" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" constant="64" id="h0h-ih-5eZ"/>
                             <constraint firstItem="IJb-Dm-Xah" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="w7c-iB-KpM"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="bottomConstraint" destination="1y0-lK-W0T" id="ONy-55-vmz"/>
                         <outlet property="greenCircleView" destination="Ovq-tt-WTY" id="Ave-zI-Wve"/>
                         <outlet property="redCircleView" destination="P7P-zn-lAU" id="vdb-yK-m1J"/>
                         <outlet property="startButton" destination="Jiv-AV-dvV" id="h8e-55-ltG"/>
+                        <outlet property="topConstraint" destination="h0h-ih-5eZ" id="p8P-et-Qen"/>
                         <outlet property="yellowCircleView" destination="8vP-ld-Ecf" id="ntG-z0-DdS"/>
                     </connections>
                 </viewController>

--- a/SwiftBook/Base.lproj/Main.storyboard
+++ b/SwiftBook/Base.lproj/Main.storyboard
@@ -4,6 +4,7 @@
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,27 +17,47 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" spacing="62" translatesAutoresizingMaskIntoConstraints="NO" id="Uus-Ye-iN0">
-                                <rect key="frame" x="143" y="103" width="128" height="508"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="Uus-Ye-iN0">
+                                <rect key="frame" x="128" y="54" width="158" height="490"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P7P-zn-lAU" userLabel="RedCircleView">
-                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P7P-zn-lAU" userLabel="RedCircleView">
+                                        <rect key="frame" x="0.0" y="0.0" width="158" height="158"/>
                                         <color key="backgroundColor" systemColor="systemRedColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="P7P-zn-lAU" secondAttribute="height" multiplier="1:1" id="4P5-vC-WwC"/>
+                                        </constraints>
                                     </view>
-                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8vP-ld-Ecf" userLabel="YellowCircleView">
-                                        <rect key="frame" x="0.0" y="190" width="128" height="128"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8vP-ld-Ecf" userLabel="YellowCircleView">
+                                        <rect key="frame" x="0.0" y="166" width="158" height="158"/>
                                         <color key="backgroundColor" systemColor="systemYellowColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="8vP-ld-Ecf" secondAttribute="height" multiplier="1:1" id="Va3-1m-vUm"/>
+                                        </constraints>
                                     </view>
-                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ovq-tt-WTY" userLabel="GreenCircleView">
-                                        <rect key="frame" x="0.0" y="380" width="128" height="128"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ovq-tt-WTY" userLabel="GreenCircleView">
+                                        <rect key="frame" x="0.0" y="332" width="158" height="158"/>
                                         <color key="backgroundColor" systemColor="systemGreenColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="Ovq-tt-WTY" secondAttribute="height" multiplier="1:1" id="rfZ-XJ-3io"/>
+                                        </constraints>
                                     </view>
                                 </subviews>
                             </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Uus-Ye-iN0" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="Pau-gf-Ly4"/>
+                            <constraint firstItem="Uus-Ye-iN0" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="10" id="aeK-85-v9S"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Uus-Ye-iN0" secondAttribute="trailing" constant="128" id="ho6-VY-Qza"/>
+                            <constraint firstItem="Uus-Ye-iN0" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="128" id="uii-DO-v4P"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="greenCircleView" destination="Ovq-tt-WTY" id="Ave-zI-Wve"/>
+                        <outlet property="redCircleView" destination="P7P-zn-lAU" id="vdb-yK-m1J"/>
+                        <outlet property="yellowCircleView" destination="8vP-ld-Ecf" id="ntG-z0-DdS"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/SwiftBook/Base.lproj/Main.storyboard
+++ b/SwiftBook/Base.lproj/Main.storyboard
@@ -61,7 +61,7 @@
                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </state>
                                         <connections>
-                                            <action selector="startNextColorLightButtonTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="KEK-rj-lfz"/>
+                                            <action selector="startNextButtonTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="KEK-rj-lfz"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/SwiftBook/Base.lproj/Main.storyboard
+++ b/SwiftBook/Base.lproj/Main.storyboard
@@ -1,24 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="SwiftBook" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" spacing="62" translatesAutoresizingMaskIntoConstraints="NO" id="Uus-Ye-iN0">
+                                <rect key="frame" x="143" y="103" width="128" height="508"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P7P-zn-lAU" userLabel="RedCircleView">
+                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <color key="backgroundColor" systemColor="systemRedColor"/>
+                                    </view>
+                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8vP-ld-Ecf" userLabel="YellowCircleView">
+                                        <rect key="frame" x="0.0" y="190" width="128" height="128"/>
+                                        <color key="backgroundColor" systemColor="systemYellowColor"/>
+                                    </view>
+                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ovq-tt-WTY" userLabel="GreenCircleView">
+                                        <rect key="frame" x="0.0" y="380" width="128" height="128"/>
+                                        <color key="backgroundColor" systemColor="systemGreenColor"/>
+                                    </view>
+                                </subviews>
+                            </stackView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="131.8840579710145" y="99.776785714285708"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGreenColor">
+            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemYellowColor">
+            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/SwiftBook/Base.lproj/Main.storyboard
+++ b/SwiftBook/Base.lproj/Main.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="Uus-Ye-iN0">
-                                <rect key="frame" x="128" y="54" width="158" height="490"/>
+                                <rect key="frame" x="128" y="74" width="158" height="490"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="P7P-zn-lAU" userLabel="RedCircleView">
                                         <rect key="frame" x="0.0" y="0.0" width="158" height="158"/>
@@ -43,19 +43,34 @@
                                     </view>
                                 </subviews>
                             </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jiv-AV-dvV">
+                                <rect key="frame" x="167" y="791" width="80" height="41"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="48j-nv-T0g"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                <state key="normal" title="Start"/>
+                                <connections>
+                                    <action selector="startNextColorLightButtonTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="KEK-rj-lfz"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="Jiv-AV-dvV" secondAttribute="bottom" constant="30" id="9qz-Wl-eYg"/>
                             <constraint firstItem="Uus-Ye-iN0" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="Pau-gf-Ly4"/>
-                            <constraint firstItem="Uus-Ye-iN0" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="10" id="aeK-85-v9S"/>
+                            <constraint firstItem="Uus-Ye-iN0" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="30" id="aeK-85-v9S"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Uus-Ye-iN0" secondAttribute="trailing" constant="128" id="ho6-VY-Qza"/>
                             <constraint firstItem="Uus-Ye-iN0" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="128" id="uii-DO-v4P"/>
+                            <constraint firstItem="Jiv-AV-dvV" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="zu4-tN-BHw"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="greenCircleView" destination="Ovq-tt-WTY" id="Ave-zI-Wve"/>
                         <outlet property="redCircleView" destination="P7P-zn-lAU" id="vdb-yK-m1J"/>
+                        <outlet property="startNextColorLightButton" destination="Jiv-AV-dvV" id="h8e-55-ltG"/>
                         <outlet property="yellowCircleView" destination="8vP-ld-Ecf" id="ntG-z0-DdS"/>
                     </connections>
                 </viewController>

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -9,11 +9,25 @@ import UIKit
 
 class ViewController: UIViewController {
 
+    @IBOutlet var redCircleView: UIView!
+    @IBOutlet var yellowCircleView: UIView!
+    @IBOutlet var greenCircleView: UIView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        
+        print("viewDidLoad:", redCircleView.frame.width / 2)
     }
+    
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
 
+        redCircleView.layer.cornerRadius = redCircleView.frame.width / 2
+        yellowCircleView.layer.cornerRadius = yellowCircleView.frame.width / 2
+        greenCircleView.layer.cornerRadius = greenCircleView.frame.width / 2
+
+        print("viewWillLayoutSubviews:", redCircleView.frame.width / 2)
+    }
 
 }
 

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -56,22 +56,42 @@ class ViewController: UIViewController {
         greenCircleView.alpha = 0.3
     }
     
-    @IBAction func startNextColorLightButtonTapped() {
-        guard startButton.currentTitle == "NEXT" else {
-            startButton.setTitle("NEXT", for: .normal)
-            redCircleView.alpha = 1
-            return
+    class TrafficLight {
+        var currentState: States?
+        
+        enum States {
+            case red
+            case yellow
+            case green
         }
         
-        if redCircleView.alpha == 1 {
-            redCircleView.alpha = 0.3
-            yellowCircleView.alpha = 1
-        } else if yellowCircleView.alpha == 1 {
-            yellowCircleView.alpha = 0.3
-            greenCircleView.alpha = 1
-        } else {
+        func nextState() {
+            switch currentState {
+            case .red:
+                currentState = .yellow
+            case .yellow:
+                currentState = .green
+            case .green:
+                currentState = .red
+            default:
+                currentState = .red
+            }
+        }
+    }
+    
+    let trafficLight = TrafficLight()
+    
+    @IBAction func startNextColorLightButtonTapped() {
+        if trafficLight.currentState == .green || trafficLight.currentState == nil {
             greenCircleView.alpha = 0.3
             redCircleView.alpha = 1
+        } else if trafficLight.currentState == .red {
+            redCircleView.alpha = 0.3
+            yellowCircleView.alpha = 1
+        } else {
+            yellowCircleView.alpha = 0.3
+            greenCircleView.alpha = 1
         }
+        trafficLight.nextState()
     }
 }

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -129,6 +129,9 @@ class ViewController: UIViewController {
     
     // MARK: - IB Actions
     @IBAction func startNextButtonTapped() {
+        if startButton.currentTitle != "NEXT" {
+            startButton.setTitle("NEXT", for: .normal)
+        }
         trafficLight.nextState()
     }
 }

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -21,9 +21,6 @@ class ViewController: UIViewController {
     
     // MARK: - Public Properties
     let trafficLight = TrafficLight()
-    let offLightState = OnOffLightToggle.off
-    let onLightState = OnOffLightToggle.on
-    
     
     // MARK: - Life Cycles Properties and Methods
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -57,38 +54,75 @@ class ViewController: UIViewController {
         yellowCircleView.layer.cornerRadius = cornerRadiusValue
         greenCircleView.layer.cornerRadius = cornerRadiusValue
         
-        redCircleView.alpha = offLightState.rawValue
-        yellowCircleView.alpha = offLightState.rawValue
-        greenCircleView.alpha = offLightState.rawValue
+        trafficLight.redCircleView = redCircleView
+        trafficLight.yellowCircleView = yellowCircleView
+        trafficLight.greenCircleView = greenCircleView
+        trafficLight.nextState()
         
         startButton.layer.cornerRadius = startButton.frame.width / (64 * mainStackAspectConstraint.multiplier)
     }
     
     // MARK: - Public objects
-    enum OnOffLightToggle: CGFloat { //one point to change On Off alpha channel fixed state of Circles
-        case off = 0.3
-        case on = 1
+    
+    enum TrafficLightsStates {
+        case red(red: OnOffLightToggle = .on, yellow: OnOffLightToggle = .off, green: OnOffLightToggle = .off)
+        case yellow(red: OnOffLightToggle = .off, yellow: OnOffLightToggle = .on, green: OnOffLightToggle = .off)
+        case green(red: OnOffLightToggle = .off, yellow: OnOffLightToggle = .off, green: OnOffLightToggle = .on)
+        case start(red: OnOffLightToggle = .off, yellow: OnOffLightToggle = .off, green: OnOffLightToggle = .off)
+        
+        enum OnOffLightToggle: CGFloat { //one point to change On Off alpha channel level of circles views
+            case off = 0.3
+            case on = 1
+        }
     }
     
     class TrafficLight {
-        var currentState: States?
+        var redCircleView: UIView?
+        var yellowCircleView: UIView?
+        var greenCircleView: UIView?
         
-        enum States {
-            case red(red: OnOffLightToggle, yellow: OnOffLightToggle, green: OnOffLightToggle)
-            case yellow(red: OnOffLightToggle, yellow: OnOffLightToggle, green: OnOffLightToggle)
-            case green(red: OnOffLightToggle, yellow: OnOffLightToggle, green: OnOffLightToggle)
-        }
+        private var currentState: TrafficLightsStates?
         
         func nextState() {
             switch currentState {
+            case .start:
+                currentState = .red()
+                applyState()
             case .red:
-                currentState = .yellow(red: .off, yellow: .on, green: .off)
+                currentState = .yellow()
+                applyState()
             case .yellow:
-                currentState = .green(red: .off, yellow: .off, green: .on)
+                currentState = .green()
+                applyState()
             case .green:
-                currentState = .red(red: .on, yellow: .off, green: .off)
+                currentState = .red()
+                applyState()
             default:
-                currentState = .red(red: .on, yellow: .off, green: .off)
+                currentState = .start()
+                applyState()
+            }
+        }
+        
+        private func applyState() {
+            switch currentState {
+            case let .start(red: redValue, yellow: yellowValue, green: greenValue):
+                redCircleView?.alpha = redValue.rawValue
+                yellowCircleView?.alpha = yellowValue.rawValue
+                greenCircleView?.alpha = greenValue.rawValue
+            case let .red(red: redValue, yellow: yellowValue, green: greenValue):
+                redCircleView?.alpha = redValue.rawValue
+                yellowCircleView?.alpha = yellowValue.rawValue
+                greenCircleView?.alpha = greenValue.rawValue
+            case let .yellow(red: redValue, yellow: yellowValue, green: greenValue):
+                redCircleView?.alpha = redValue.rawValue
+                yellowCircleView?.alpha = yellowValue.rawValue
+                greenCircleView?.alpha = greenValue.rawValue
+            case let .green(red: redValue, yellow: yellowValue, green: greenValue):
+                redCircleView?.alpha = redValue.rawValue
+                yellowCircleView?.alpha = yellowValue.rawValue
+                greenCircleView?.alpha = greenValue.rawValue
+            default:
+                break
             }
         }
     }
@@ -96,22 +130,5 @@ class ViewController: UIViewController {
     // MARK: - IB Actions
     @IBAction func startNextButtonTapped() {
         trafficLight.nextState()
-        
-        switch trafficLight.currentState {
-        case let .red(red: redValue, yellow: yellowValue, green: greenValue):
-            redCircleView.alpha = redValue.rawValue
-            yellowCircleView.alpha = yellowValue.rawValue
-            greenCircleView.alpha = greenValue.rawValue
-        case let .yellow(red: redValue, yellow: yellowValue, green: greenValue):
-            redCircleView.alpha = redValue.rawValue
-            yellowCircleView.alpha = yellowValue.rawValue
-            greenCircleView.alpha = greenValue.rawValue
-        case let .green(red: redValue, yellow: yellowValue, green: greenValue):
-            redCircleView.alpha = redValue.rawValue
-            yellowCircleView.alpha = yellowValue.rawValue
-            greenCircleView.alpha = greenValue.rawValue
-        default:
-            break
-        }
     }
 }

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -14,8 +14,9 @@ class ViewController: UIViewController {
     @IBOutlet var greenCircleView: UIView!
     @IBOutlet var startButton: UIButton!
     
-    @IBOutlet var topConstraint: NSLayoutConstraint!
-    @IBOutlet var bottomConstraint: NSLayoutConstraint!
+    @IBOutlet var mainStacktopConstraint: NSLayoutConstraint!
+    @IBOutlet var mainStackBottomConstraint: NSLayoutConstraint!
+    @IBOutlet var mainStackAspectConstraint: NSLayoutConstraint!
     
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         .portrait
@@ -24,38 +25,35 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        /// hide objects to sneak transform:
-        redCircleView.alpha = 0
-        yellowCircleView.alpha = 0
-        greenCircleView.alpha = 0
-        startButton.alpha = 0
+        var topSafeAreaHeight: CGFloat = 0
+        var bottomSafeAreaHeight: CGFloat = 0
+        let screenBounds = (UIScreen.main.bounds).size.height
         
-//        stackOfCirclesAndButton.topAnchor.constraint(equalTo: stackOfCirclesAndButton.bottomAnchor, constant: 10)
-//        redCircleView.layer.cornerRadius = ((UIScreen.main.bounds).size.width / 5 - stackOfCirclesAndButton.topAnchor)
+        if #available(iOS 11.0, *) {
+            let scenes = UIApplication.shared.connectedScenes
+            let windowScene = scenes.first as? UIWindowScene
+            let window = windowScene?.windows.first
+            let safeFrame = window?.safeAreaLayoutGuide.layoutFrame
+            
+            topSafeAreaHeight = safeFrame?.minY ?? 0
+            bottomSafeAreaHeight = (window?.frame.maxY ?? 0) - (safeFrame?.maxY ?? 0)
+            // topSafeAreaHeight and bottomSafeAreaHeight is now available
+        }
         
-//        print((UIApplication.shared.windows.first)?.safeAreaInsets.top)
-     //   print((UIWindowScene.windows.first)?.safeAreaInsets.top)
-//        
-//        print(view.safeAreaLayoutGuide)
-//        print((view.safeAreaLayoutGuide).layoutFrame.size.height)
+        let mainAspectSizeVertical = 10 / (mainStackAspectConstraint.multiplier * 10)
+        let heighOfMainStack = screenBounds - topSafeAreaHeight - bottomSafeAreaHeight - mainStacktopConstraint.constant - mainStackBottomConstraint.constant
+        let widthOfMainStack = heighOfMainStack / mainAspectSizeVertical
+        let cornerRadiusValue = widthOfMainStack / 2
         
-        redCircleView.layer.cornerRadius = (((UIScreen.main.bounds).size.height - topConstraint.constant - bottomConstraint.constant) / 5) / 2
-        yellowCircleView.layer.cornerRadius = (((UIScreen.main.bounds).size.height - topConstraint.constant - bottomConstraint.constant) / 5) / 2
-        greenCircleView.layer.cornerRadius = (((UIScreen.main.bounds).size.height - topConstraint.constant - bottomConstraint.constant) / 5) / 2
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+        redCircleView.layer.cornerRadius = cornerRadiusValue
+        yellowCircleView.layer.cornerRadius = cornerRadiusValue
+        greenCircleView.layer.cornerRadius = cornerRadiusValue
         
-
+        startButton.layer.cornerRadius = startButton.frame.width / (64 * mainStackAspectConstraint.multiplier)
         
-        startButton.layer.cornerRadius = startButton.frame.width / 16
-        
-        ///show objects after transformation:
         redCircleView.alpha = 0.3
         yellowCircleView.alpha = 0.3
         greenCircleView.alpha = 0.3
-        startButton.alpha = 1
     }
     
     @IBAction func startNextColorLightButtonTapped() {

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -14,6 +14,9 @@ class ViewController: UIViewController {
     @IBOutlet var greenCircleView: UIView!
     @IBOutlet var startButton: UIButton!
     
+    @IBOutlet var topConstraint: NSLayoutConstraint!
+    @IBOutlet var bottomConstraint: NSLayoutConstraint!
+    
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         .portrait
     }
@@ -26,14 +29,25 @@ class ViewController: UIViewController {
         yellowCircleView.alpha = 0
         greenCircleView.alpha = 0
         startButton.alpha = 0
+        
+//        stackOfCirclesAndButton.topAnchor.constraint(equalTo: stackOfCirclesAndButton.bottomAnchor, constant: 10)
+//        redCircleView.layer.cornerRadius = ((UIScreen.main.bounds).size.width / 5 - stackOfCirclesAndButton.topAnchor)
+        
+//        print((UIApplication.shared.windows.first)?.safeAreaInsets.top)
+     //   print((UIWindowScene.windows.first)?.safeAreaInsets.top)
+//        
+//        print(view.safeAreaLayoutGuide)
+//        print((view.safeAreaLayoutGuide).layoutFrame.size.height)
+        
+        redCircleView.layer.cornerRadius = (((UIScreen.main.bounds).size.height - topConstraint.constant - bottomConstraint.constant) / 5) / 2
+        yellowCircleView.layer.cornerRadius = (((UIScreen.main.bounds).size.height - topConstraint.constant - bottomConstraint.constant) / 5) / 2
+        greenCircleView.layer.cornerRadius = (((UIScreen.main.bounds).size.height - topConstraint.constant - bottomConstraint.constant) / 5) / 2
     }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        redCircleView.layer.cornerRadius = redCircleView.frame.width / 2
-        yellowCircleView.layer.cornerRadius = yellowCircleView.frame.width / 2
-        greenCircleView.layer.cornerRadius = greenCircleView.frame.width / 2
+
         
         startButton.layer.cornerRadius = startButton.frame.width / 16
         
@@ -62,6 +76,4 @@ class ViewController: UIViewController {
             redCircleView.alpha = 1
         }
     }
-    
-    
 }

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -21,6 +21,9 @@ class ViewController: UIViewController {
     
     // MARK: - Public Properties
     let trafficLight = TrafficLight()
+    let offLightState = OnOffLightToggle.off
+    let onLightState = OnOffLightToggle.on
+    
     
     // MARK: - Life Cycles Properties and Methods
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -54,33 +57,38 @@ class ViewController: UIViewController {
         yellowCircleView.layer.cornerRadius = cornerRadiusValue
         greenCircleView.layer.cornerRadius = cornerRadiusValue
         
-        startButton.layer.cornerRadius = startButton.frame.width / (64 * mainStackAspectConstraint.multiplier)
+        redCircleView.alpha = offLightState.rawValue
+        yellowCircleView.alpha = offLightState.rawValue
+        greenCircleView.alpha = offLightState.rawValue
         
-        redCircleView.alpha = 0.3
-        yellowCircleView.alpha = 0.3
-        greenCircleView.alpha = 0.3
+        startButton.layer.cornerRadius = startButton.frame.width / (64 * mainStackAspectConstraint.multiplier)
     }
     
     // MARK: - Public objects
+    enum OnOffLightToggle: CGFloat { //one point to change On Off alpha channel fixed state of Circles
+        case off = 0.3
+        case on = 1
+    }
+    
     class TrafficLight {
         var currentState: States?
         
         enum States {
-            case red(red: CGFloat, yellow: CGFloat, green: CGFloat)
-            case yellow(red: CGFloat, yellow: CGFloat, green: CGFloat)
-            case green(red: CGFloat, yellow: CGFloat, green: CGFloat)
+            case red(red: OnOffLightToggle, yellow: OnOffLightToggle, green: OnOffLightToggle)
+            case yellow(red: OnOffLightToggle, yellow: OnOffLightToggle, green: OnOffLightToggle)
+            case green(red: OnOffLightToggle, yellow: OnOffLightToggle, green: OnOffLightToggle)
         }
         
         func nextState() {
             switch currentState {
             case .red:
-                currentState = .yellow(red: 0.3, yellow: 1, green: 0.3)
+                currentState = .yellow(red: .off, yellow: .on, green: .off)
             case .yellow:
-                currentState = .green(red: 0.3, yellow: 0.3, green: 1)
+                currentState = .green(red: .off, yellow: .off, green: .on)
             case .green:
-                currentState = .red(red: 1, yellow: 0.3, green: 0.3)
+                currentState = .red(red: .on, yellow: .off, green: .off)
             default:
-                currentState = .red(red: 1, yellow: 0.3, green: 0.3)
+                currentState = .red(red: .on, yellow: .off, green: .off)
             }
         }
     }
@@ -91,17 +99,17 @@ class ViewController: UIViewController {
         
         switch trafficLight.currentState {
         case let .red(red: redValue, yellow: yellowValue, green: greenValue):
-            redCircleView.alpha = redValue
-            yellowCircleView.alpha = yellowValue
-            greenCircleView.alpha = greenValue
+            redCircleView.alpha = redValue.rawValue
+            yellowCircleView.alpha = yellowValue.rawValue
+            greenCircleView.alpha = greenValue.rawValue
         case let .yellow(red: redValue, yellow: yellowValue, green: greenValue):
-            redCircleView.alpha = redValue
-            yellowCircleView.alpha = yellowValue
-            greenCircleView.alpha = greenValue
+            redCircleView.alpha = redValue.rawValue
+            yellowCircleView.alpha = yellowValue.rawValue
+            greenCircleView.alpha = greenValue.rawValue
         case let .green(red: redValue, yellow: yellowValue, green: greenValue):
-            redCircleView.alpha = redValue
-            yellowCircleView.alpha = yellowValue
-            greenCircleView.alpha = greenValue
+            redCircleView.alpha = redValue.rawValue
+            yellowCircleView.alpha = yellowValue.rawValue
+            greenCircleView.alpha = greenValue.rawValue
         default:
             break
         }

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -58,38 +58,47 @@ class ViewController: UIViewController {
     
     class TrafficLight {
         var currentState: States?
-        var currentStateValue: (red: CGFloat, yellow: CGFloat, green: CGFloat) = (0, 0, 0)
         
         enum States {
-            case red
-            case yellow
-            case green
+            case red(red: CGFloat, yellow: CGFloat, green: CGFloat)
+            case yellow(red: CGFloat, yellow: CGFloat, green: CGFloat)
+            case green(red: CGFloat, yellow: CGFloat, green: CGFloat)
         }
         
         func nextState() {
             switch currentState {
             case .red:
-                currentState = .yellow
-                currentStateValue = (red: 0.3, yellow: 1, green: 0.3)
+                currentState = .yellow(red: 0.3, yellow: 1, green: 0.3)
             case .yellow:
-                currentState = .green
-                currentStateValue = (red: 0.3, yellow: 0.3, green: 1)
+                currentState = .green(red: 0.3, yellow: 0.3, green: 1)
             case .green:
-                currentState = .red
-                currentStateValue = (red: 1, yellow: 0.3, green: 0.3)
+                currentState = .red(red: 1, yellow: 0.3, green: 0.3)
             default:
-                currentState = .red
-                currentStateValue = (red: 1, yellow: 0.3, green: 0.3)
+                currentState = .red(red: 1, yellow: 0.3, green: 0.3)
             }
         }
     }
     
     let trafficLight = TrafficLight()
     
-    @IBAction func startNextColorLightButtonTapped() {
+    @IBAction func startNextButtonTapped() {
         trafficLight.nextState()
-        redCircleView.alpha = trafficLight.currentStateValue.red
-        yellowCircleView.alpha = trafficLight.currentStateValue.yellow
-        greenCircleView.alpha = trafficLight.currentStateValue.green
+        
+        switch trafficLight.currentState {
+        case let .red(red: redValue, yellow: yellowValue, green: greenValue):
+            redCircleView.alpha = redValue
+            yellowCircleView.alpha = yellowValue
+            greenCircleView.alpha = greenValue
+        case let .yellow(red: redValue, yellow: yellowValue, green: greenValue):
+            redCircleView.alpha = redValue
+            yellowCircleView.alpha = yellowValue
+            greenCircleView.alpha = greenValue
+        case let .green(red: redValue, yellow: yellowValue, green: greenValue):
+            redCircleView.alpha = redValue
+            yellowCircleView.alpha = yellowValue
+            greenCircleView.alpha = greenValue
+        default:
+            break
+        }
     }
 }

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -58,6 +58,7 @@ class ViewController: UIViewController {
     
     class TrafficLight {
         var currentState: States?
+        var currentStateValue: (red: CGFloat, yellow: CGFloat, green: CGFloat) = (0, 0, 0)
         
         enum States {
             case red
@@ -69,12 +70,16 @@ class ViewController: UIViewController {
             switch currentState {
             case .red:
                 currentState = .yellow
+                currentStateValue = (red: 0.3, yellow: 1, green: 0.3)
             case .yellow:
                 currentState = .green
+                currentStateValue = (red: 0.3, yellow: 0.3, green: 1)
             case .green:
                 currentState = .red
+                currentStateValue = (red: 1, yellow: 0.3, green: 0.3)
             default:
                 currentState = .red
+                currentStateValue = (red: 1, yellow: 0.3, green: 0.3)
             }
         }
     }
@@ -82,16 +87,9 @@ class ViewController: UIViewController {
     let trafficLight = TrafficLight()
     
     @IBAction func startNextColorLightButtonTapped() {
-        if trafficLight.currentState == .green || trafficLight.currentState == nil {
-            greenCircleView.alpha = 0.3
-            redCircleView.alpha = 1
-        } else if trafficLight.currentState == .red {
-            redCircleView.alpha = 0.3
-            yellowCircleView.alpha = 1
-        } else {
-            yellowCircleView.alpha = 0.3
-            greenCircleView.alpha = 1
-        }
         trafficLight.nextState()
+        redCircleView.alpha = trafficLight.currentStateValue.red
+        yellowCircleView.alpha = trafficLight.currentStateValue.yellow
+        greenCircleView.alpha = trafficLight.currentStateValue.green
     }
 }

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class ViewController: UIViewController {
     
+    // MARK: - IB Outlets
     @IBOutlet var redCircleView: UIView!
     @IBOutlet var yellowCircleView: UIView!
     @IBOutlet var greenCircleView: UIView!
@@ -18,6 +19,10 @@ class ViewController: UIViewController {
     @IBOutlet var mainStackBottomConstraint: NSLayoutConstraint!
     @IBOutlet var mainStackAspectConstraint: NSLayoutConstraint!
     
+    // MARK: - Public Properties
+    let trafficLight = TrafficLight()
+    
+    // MARK: - Life Cycles Properties and Methods
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         .portrait
     }
@@ -40,7 +45,7 @@ class ViewController: UIViewController {
             // topSafeAreaHeight and bottomSafeAreaHeight is now available
         }
         
-        let mainAspectSizeVertical = 10 / (mainStackAspectConstraint.multiplier * 10)
+        let mainAspectSizeVertical = 1 / (mainStackAspectConstraint.multiplier)
         let heighOfMainStack = screenBounds - topSafeAreaHeight - bottomSafeAreaHeight - mainStacktopConstraint.constant - mainStackBottomConstraint.constant
         let widthOfMainStack = heighOfMainStack / mainAspectSizeVertical
         let cornerRadiusValue = widthOfMainStack / 2
@@ -56,6 +61,7 @@ class ViewController: UIViewController {
         greenCircleView.alpha = 0.3
     }
     
+    // MARK: - Public objects
     class TrafficLight {
         var currentState: States?
         
@@ -79,8 +85,7 @@ class ViewController: UIViewController {
         }
     }
     
-    let trafficLight = TrafficLight()
-    
+    // MARK: - IB Actions
     @IBAction func startNextButtonTapped() {
         trafficLight.nextState()
         

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController {
     @IBOutlet var greenCircleView: UIView!
     @IBOutlet var startButton: UIButton!
     
-    @IBOutlet var mainStacktopConstraint: NSLayoutConstraint!
+    @IBOutlet var mainStackTopConstraint: NSLayoutConstraint!
     @IBOutlet var mainStackBottomConstraint: NSLayoutConstraint!
     @IBOutlet var mainStackAspectConstraint: NSLayoutConstraint!
     
@@ -45,9 +45,9 @@ class ViewController: UIViewController {
             // topSafeAreaHeight and bottomSafeAreaHeight is now available
         }
         
-        let mainAspectSizeVertical = 1 / (mainStackAspectConstraint.multiplier)
-        let heighOfMainStack = screenBounds - topSafeAreaHeight - bottomSafeAreaHeight - mainStacktopConstraint.constant - mainStackBottomConstraint.constant
-        let widthOfMainStack = heighOfMainStack / mainAspectSizeVertical
+        let heighOfMainStack = screenBounds - topSafeAreaHeight - bottomSafeAreaHeight - mainStackTopConstraint.constant - mainStackBottomConstraint.constant
+        let mainStackAspectMultiplierDevider = 1 / (mainStackAspectConstraint.multiplier)
+        let widthOfMainStack = heighOfMainStack / mainStackAspectMultiplierDevider
         let cornerRadiusValue = widthOfMainStack / 2
         
         redCircleView.layer.cornerRadius = cornerRadiusValue
@@ -70,7 +70,7 @@ class ViewController: UIViewController {
         case green(red: OnOffLightToggle = .off, yellow: OnOffLightToggle = .off, green: OnOffLightToggle = .on)
         case start(red: OnOffLightToggle = .off, yellow: OnOffLightToggle = .off, green: OnOffLightToggle = .off)
         
-        enum OnOffLightToggle: CGFloat { //one point to change On Off alpha channel level of circles views
+        enum OnOffLightToggle: CGFloat { //one point to change On/Off alpha channel level for circles views
             case off = 0.3
             case on = 1
         }
@@ -87,23 +87,23 @@ class ViewController: UIViewController {
             switch currentState {
             case .start:
                 currentState = .red()
-                applyState()
+                setToCircles()
             case .red:
                 currentState = .yellow()
-                applyState()
+                setToCircles()
             case .yellow:
                 currentState = .green()
-                applyState()
+                setToCircles()
             case .green:
                 currentState = .red()
-                applyState()
+                setToCircles()
             default:
                 currentState = .start()
-                applyState()
+                setToCircles()
             }
         }
         
-        private func applyState() {
+        private func setToCircles() {
             switch currentState {
             case let .start(red: redValue, yellow: yellowValue, green: greenValue):
                 redCircleView?.alpha = redValue.rawValue

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -13,7 +13,11 @@ class ViewController: UIViewController {
     @IBOutlet var yellowCircleView: UIView!
     @IBOutlet var greenCircleView: UIView!
     @IBOutlet var startButton: UIButton!
-       
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        .portrait
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -21,6 +25,7 @@ class ViewController: UIViewController {
         redCircleView.alpha = 0
         yellowCircleView.alpha = 0
         greenCircleView.alpha = 0
+        startButton.alpha = 0
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -30,17 +35,32 @@ class ViewController: UIViewController {
         yellowCircleView.layer.cornerRadius = yellowCircleView.frame.width / 2
         greenCircleView.layer.cornerRadius = greenCircleView.frame.width / 2
         
-        ///immediately show objects after transformation(with hometask start a-level):
+        startButton.layer.cornerRadius = startButton.frame.width / 16
+        
+        ///show objects after transformation:
         redCircleView.alpha = 0.3
         yellowCircleView.alpha = 0.3
         greenCircleView.alpha = 0.3
+        startButton.alpha = 1
     }
     
     @IBAction func startNextColorLightButtonTapped() {
-//        if redCircleView.alpha < 1 && yellowCircleView.alpha < 1 && greenCircleView.alpha < 1 {
-//            startNextColorLightButton.setTitle("Next", for: .normal)
-//        }
-    
+        guard startButton.currentTitle == "NEXT" else {
+            startButton.setTitle("NEXT", for: .normal)
+            redCircleView.alpha = 1
+            return
+        }
+        
+        if redCircleView.alpha == 1 {
+            redCircleView.alpha = 0.3
+            yellowCircleView.alpha = 1
+        } else if yellowCircleView.alpha == 1 {
+            yellowCircleView.alpha = 0.3
+            greenCircleView.alpha = 1
+        } else {
+            greenCircleView.alpha = 0.3
+            redCircleView.alpha = 1
+        }
     }
     
     

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -22,11 +22,12 @@ class ViewController: UIViewController {
     // MARK: - Public Properties
     let trafficLight = TrafficLight()
     
-    // MARK: - Life Cycles Properties and Methods
+    // MARK: - Overrided properties
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         .portrait
     }
     
+    // MARK: - Life Cycles Methods
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -77,12 +78,15 @@ class ViewController: UIViewController {
     }
     
     class TrafficLight {
+        // MARK: - Public Properties
         var redCircleView: UIView?
         var yellowCircleView: UIView?
         var greenCircleView: UIView?
         
+        // MARK: - Private Properties
         private var currentState: TrafficLightsStates?
         
+        // MARK: - Pubic Methods
         func nextState() {
             switch currentState {
             case .start:
@@ -103,6 +107,7 @@ class ViewController: UIViewController {
             }
         }
         
+        // MARK: - Private Methods
         private func setToCircles() {
             switch currentState {
             case let .start(red: redValue, yellow: yellowValue, green: greenValue):
@@ -127,7 +132,7 @@ class ViewController: UIViewController {
         }
     }
     
-    // MARK: - IB Actions
+    // MARK: - IBActions
     @IBAction func startNextButtonTapped() {
         if startButton.currentTitle != "NEXT" {
             startButton.setTitle("NEXT", for: .normal)

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -12,7 +12,7 @@ class ViewController: UIViewController {
     @IBOutlet var redCircleView: UIView!
     @IBOutlet var yellowCircleView: UIView!
     @IBOutlet var greenCircleView: UIView!
-    @IBOutlet var startNextColorLightButton: UIButton!
+    @IBOutlet var startButton: UIButton!
        
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -37,9 +37,10 @@ class ViewController: UIViewController {
     }
     
     @IBAction func startNextColorLightButtonTapped() {
-        if redCircleView.alpha < 1 && yellowCircleView.alpha < 1 && greenCircleView.alpha < 1 {
-            startNextColorLightButton.setTitle("Next", for: .normal)
-        }
+//        if redCircleView.alpha < 1 && yellowCircleView.alpha < 1 && greenCircleView.alpha < 1 {
+//            startNextColorLightButton.setTitle("Next", for: .normal)
+//        }
+    
     }
     
     

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -8,22 +8,39 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    
     @IBOutlet var redCircleView: UIView!
     @IBOutlet var yellowCircleView: UIView!
     @IBOutlet var greenCircleView: UIView!
-    
+    @IBOutlet var startNextColorLightButton: UIButton!
+       
     override func viewDidLoad() {
         super.viewDidLoad()
-    }
         
+        /// hide objects to sneak transform:
+        redCircleView.alpha = 0
+        yellowCircleView.alpha = 0
+        greenCircleView.alpha = 0
+    }
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
+        
         redCircleView.layer.cornerRadius = redCircleView.frame.width / 2
         yellowCircleView.layer.cornerRadius = yellowCircleView.frame.width / 2
         greenCircleView.layer.cornerRadius = greenCircleView.frame.width / 2
+        
+        ///immediately show objects after transformation(with hometask start a-level):
+        redCircleView.alpha = 0.3
+        yellowCircleView.alpha = 0.3
+        greenCircleView.alpha = 0.3
     }
-
+    
+    @IBAction func startNextColorLightButtonTapped() {
+        if redCircleView.alpha < 1 && yellowCircleView.alpha < 1 && greenCircleView.alpha < 1 {
+            startNextColorLightButton.setTitle("Next", for: .normal)
+        }
+    }
+    
+    
 }
-

--- a/SwiftBook/ViewController.swift
+++ b/SwiftBook/ViewController.swift
@@ -15,18 +15,14 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        print("viewDidLoad:", redCircleView.frame.width / 2)
     }
-    
-    override func viewWillLayoutSubviews() {
-        super.viewWillLayoutSubviews()
+        
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
 
         redCircleView.layer.cornerRadius = redCircleView.frame.width / 2
         yellowCircleView.layer.cornerRadius = yellowCircleView.frame.width / 2
         greenCircleView.layer.cornerRadius = greenCircleView.frame.width / 2
-
-        print("viewWillLayoutSubviews:", redCircleView.frame.width / 2)
     }
 
 }


### PR DESCRIPTION
Сложности и вопросы, ответ на которые придёт с опытом:
ДАНО:
1.	Завершён первый модуль, и мы уже знаем про классы и перечисления.
2.	Завершён первый урок 2 модуля (мы узнали про constraints)
3.	Просмотрен 3 урок и мы узнали про @IBActions и @IBAutlets
Чего мы не знаем:
Мы не знаем про жизненный цикл view, SceneDeleage (делаем попытки влезть в тему)

===== ПРОБЛЕМА: =====
Также в ходе выполнения задания мы выявляем проблему:
«Для переключения сигналов светофора используйте кнопку со стилем Default». 

В ходе выполнения задания очевидным решением становится использование:
@IBOutlet var redCircleView: UIView!
redCircleView.layer.cornerRadius = redCircleView.frame.width / 2

===== viewDidLoad =====
Мы прописываем это в метод viewDidLoad и получаем вместо квадрата нечто(его некорректное скругление, которое происходит на основе текущих размеров view без учёта изменений от размера экрана конечного устройства). Нам говорили что viewDidLoad это «view загружен», но через цепочку redCircleView.frame.width мы обращаемся к ширине отрисованного фрейма, а его ещё на сцене нет. viewDidLoad хоть и вызывается после загрузки всех отображений, но пока не выводит сцену на экран(позволяет сделать финальные правки перед выводом на экран). Таким образом, viewDidLoad для решения задачи таким простым и быстрым путём нам не подходит.

===== viewWillLayoutSubViews =====
Следующий вариант самый противоречивый(читай: однозначно костыльный). Это использование viewWillLayoutSubViews. Данный «хитрый» метод если в него поместить нашу строчку «redCircleView.layer.cornerRadius = redCircleView.frame.width / 2» сработает сразу, но при этом «redCircleView.frame.width» будет равно нулю, что в результате выведет нам квадрат. При нажатии на любой элемент интерфейса программы вызовет нам метод повторно и «redCircleView.frame.width» уже покажет нам реальную ширину фрейма. Далее обращение к Сенсею по этому поводу показало, что необходимо использовать Default button чтобы «интерфейс обновился». И действительно, как только я заменил кнопку на Default программа отработала корректно. Но если интерфейс вообще лишить кнопок, то магия исчезает и вместо скруглённых квадратов (окружностей) мы получаем снова исходные квадраты. Почему так, загадка: … «Одним словом загадка, которую мы пока не решили, но ты молодец» и др. побудило на дальнейшее копание в проблеме.
Тоесть скругление «redCircleView.layer.cornerRadius = redCircleView.frame.width / 2» в методе viewWillLayoutSubViews работает «костыльно», срабатывает несколько раз, и срабатывает в нужном нам виде (когда redCircleView.frame.width не равно 0) только при наличии кнопки в режиме Default (кнопка активирует viewWillLayoutSubViews). 

viewWillLayoutSubViews  вызывается перед построением и при определённом событии:
« https://stackoverflow.com/questions/728372/when-is-layoutsubviews-called
	init does not cause layoutSubviews to be called (duh)
	addSubview: causes layoutSubviews to be called on the view being added, the view it’s being added to (target view), and all the subviews of the target
	view setFrame intelligently calls layoutSubviews on the view having its frame set only if the size parameter of the frame is different
	scrolling a UIScrollView causes layoutSubviews to be called on the scrollView, and its superview
	rotating a device only calls layoutSubview on the parent view (the responding viewControllers primary view)
	Resizing a view will call layoutSubviews on its superview (Important: views with an intrinsic content size will re-size if the content that determines their size changes; for example, updating the text on a UILabel will cause the intrinsic content size to be updated and thus call layoutSubviews on its superview)
»

Соответственно кнопка Default не исправляет метод viewWillLayoutSubViews и не является «Magic», а является костылём который в связи со стечением обстоятельств при запуске программы сразу после построения «redCircleView.frame» активирует viewWillLayoutSubViews  и мы получаем корректное значение redCircleView.frame.width и, соответственно код «redCircleView.layer.cornerRadius = redCircleView.frame.width / 2 отрабатывает корректно. Но стоит нам удалить кнопку или изменить её тип с Default на другой, как мы получим квадраты и только одно из вышеописанных событий позволит нам их скруглить. Это некорректное решение так как есть зависимость работы базового метода viewWillLayoutSubViews от постороннего объекта, сам метод viewWillLayoutSubViews срабатывает многократно при вызове одного из шести вышеописанных событий. В случае тормозов программы теоретически даже возможен вариант появления квадратов на экране и только потом сработка скругления так как в принципе redCircleView.frame.width опирается на уже отображённый объект.

По вышеописанным причинам viewWillLayoutSubViews имеет ряд особенностей (повторный вызов по 6 событиям), которые не позволяют нам его рекомендовать в качестве решения.

===== viewDidAppear (SUGAR METHOD) =====
	Метод был включен как решение домашки 2.2 под номером 2 (https://github.com/texhapcom/SwiftBook.git, [git@github.com:texhapcom/SwiftBook.git](mailto:git@github.com:texhapcom/SwiftBook.git))
Этот метод вызывается уже после того как элементы добавлены в иерархию view (элементы построены на сцене). Соответственно у нас есть корректный метод, который сработает только 1 раз и выдаст нам всегда корректные redCircleView.frame.width, так как эти размеры ширины фрейма уже точно известны (отмасштабированы и выведены на экран). Остаётся маленькая проблема в том, что несмотря на то, что с виду «всё работает» у нас остаётся факт того, что если будет сильный лаг между завершением построения фигур и срабатываем метода viewDidAppear, то мы сначала увидим квадраты, а потом уже увидим их скруглённый вариант. Максимально надёжное и простое решение это использование:
override func viewDidLoad() {
        super.viewDidLoad()
        redCircleView.alpha = 0
}

    override func viewDidAppear(_ animated: Bool) {
        super.viewDidAppear(animated)
        
        redCircleView.layer.cornerRadius = redCircleView.frame.width / 2
        
        ///show objects after transformation:
        redCircleView.alpha = 0.3
    }

Таким образом, до построения альфаканал нашего объета view равен 0, а сразу после трансформации в том же методе viewDidAppear мы его показываем пользователю в корректном виде.

Решение с redCircleView.isHidden не работает, так как XCode не проводит построение такого объекта и мы не получим корректных значений redCircleView.frame.width когда redCircleView.isHidden = true.

Что может не нравиться в подобном решении? В целом решение рабочее, поэтому включено во второй вариант решения ДЗ (по факту по коммитам можно увидить что оно идёт значительно раньше основного решения с viewDidLoad). Мы визуально скрываем наши объекты до построения, проводим их построение и потом отображаем. Profit…

===== ИТОГ(ВЫВОД) =====

Самый главный вывод который нужно сделать для понимания в том, что «redCircleView.frame.width» опирается на размеры конечного построенного объекта. Но по сути мы ищем такой момент в жизненном цикле view когда XCode уже построил «Каркас» view и знает его конечные размеры перед построением, но ещё не вывел на экран. Если бы мы нашли такой момент и могли обратиться к размерам этого «каркаса», то решили бы нашу проблему без «скрывания» объектов одной строчкой аналогичной «redCircleView.layer.cornerRadius = redCircleView.frame.width / 2». Поэтому пока мы не найдём этот момент с «каркасом» или будем завесить от самого популярного в Гугле варианта redCircleView.layer.cornerRadius = redCircleView.frame.width / 2, то мы получим лучшее как показано выше во viewDidAppear.

===== viewDidLoad =====
Но что, если мы бросим решение с «redCircleView.frame.width / 2»? Как мы можем получить размеры будущего фрейма view? Очень просто. Нам нужно найти реальные размеры нашего экрана и сделать то, что делают наши constraints.
Код:
        let screenBounds = (UIScreen.main.bounds).size.height

Теперь зная размеры экрана нам нужно учесть safeArea. (найден в Гугле и слегка доделан в соответствии с замечаниями XCode)

        var topSafeAreaHeight: CGFloat = 0
        var bottomSafeAreaHeight: CGFloat = 0

        
        if #available(iOS 11.0, *) {
            let scenes = UIApplication.shared.connectedScenes
            let windowScene = scenes.first as? UIWindowScene
            let window = windowScene?.windows.first
            let safeFrame = window?.safeAreaLayoutGuide.layoutFrame
            
            topSafeAreaHeight = safeFrame?.minY ?? 0
            bottomSafeAreaHeight = (window?.frame.maxY ?? 0) - (safeFrame?.maxY ?? 0)
            // topSafeAreaHeight and bottomSafeAreaHeight is now available
        }

Через аутлеты мы получаем доступ к текущим значениям наших вертикальных constraints. В итоге мы находим все те значения (safe area + constraints), которые вычитаем из общей высоты экрана и получаем значение высоты нашего stack исходя из чего по пропорциям находим его ширину (читай - ширину нашего view), от которой получаем значение, на которое нужно округлить наш view, чтоб получить окружность:
        let heighOfMainStack = screenBounds - topSafeAreaHeight - bottomSafeAreaHeight - mainStackTopConstraint.constant - mainStackBottomConstraint.constant
        let mainStackAspectMultiplierDevider = 1 / (mainStackAspectConstraint.multiplier)
        let widthOfMainStack = heighOfMainStack / mainStackAspectMultiplierDevider
        let cornerRadiusValue = widthOfMainStack / 2
        
        redCircleView.layer.cornerRadius = cornerRadiusValue
        yellowCircleView.layer.cornerRadius = cornerRadiusValue
        greenCircleView.layer.cornerRadius = cornerRadiusValue

Минус решения состоит в том, что если мы ходим кардинально изменить constrains (удалить текущие и добавить новые), то придётся пересчитывать значения. Но если мы не хотим удалять или добавлять constrainst то всё будет высчитываться корректно, даже если изменить значения текущих constraints.

Также этот код необходимо вывести за ViewDidLoad в объект или отдельный метод.

Главный плюс состоит в том, что мы до отображения любых объектов и до их масштабирования XCode имеем их финальные характеристики и можем с ними работать.

Transforming of CircleViews in viewDidLoad
Added object "class TrafficLight" to work with circles
Added "enum TrafficLightsStates" to get "one point to change On/Off alpha channel level for circles views"
Code "topSafeAreaHeight and bottomSafeAreaHeight is now available" was found (google) and little bit changed to hide Attention from Xcode

 "let cornerRadiusValue" it's way to exception of use transformation in ViewDidAppear, because it's requires hide/show objects (on branch homework2.2.2) to exception of view squares with lags (slowly loading).

Marks added after reading Alex recommendations (debash.medium.com)

PS: sorry for my English